### PR TITLE
Synced with upstream 5.0.14, added Hungarian translation

### DIFF
--- a/Custom/Kernel/Modules/AdminGenericAgent.pm
+++ b/Custom/Kernel/Modules/AdminGenericAgent.pm
@@ -12,6 +12,7 @@ use strict;
 use warnings;
 
 use Kernel::System::VariableCheck qw(:all);
+use Kernel::Language qw(Translatable);
 
 our $ObjectManagerDisabled = 1;
 
@@ -663,21 +664,21 @@ sub _MaskUpdate {
         );
         $JobData{ $Type . 'TimePointStart' } = $LayoutObject->BuildSelection(
             Data => {
-                Last   => 'within the last ...',
-                Next   => 'within the next ...',
-                Before => 'more than ... ago',
+                Last   => Translatable('within the last ...'),
+                Next   => Translatable('within the next ...'),
+                Before => Translatable('more than ... ago'),
             },
             Name       => $Type . 'TimePointStart',
             SelectedID => $JobData{ $Type . 'TimePointStart' } || 'Last',
         );
         $JobData{ $Type . 'TimePointFormat' } = $LayoutObject->BuildSelection(
             Data => {
-                minute => 'minute(s)',
-                hour   => 'hour(s)',
-                day    => 'day(s)',
-                week   => 'week(s)',
-                month  => 'month(s)',
-                year   => 'year(s)',
+                minute => Translatable('minute(s)'),
+                hour   => Translatable('hour(s)'),
+                day    => Translatable('day(s)'),
+                week   => Translatable('week(s)'),
+                month  => Translatable('month(s)'),
+                year   => Translatable('year(s)'),
             },
             Name       => $Type . 'TimePointFormat',
             SelectedID => $JobData{ $Type . 'TimePointFormat' },
@@ -841,7 +842,7 @@ sub _MaskUpdate {
         # get list type
         my %Service = $Kernel::OM->Get('Kernel::System::Service')->ServiceList(
             Valid        => 1,
-            KeepChildren => 1,
+            KeepChildren => $ConfigObject->Get('Ticket::Service::KeepChildren') // 0,
             UserID       => $Self->{UserID},
         );
         my %NewService = %Service;
@@ -937,9 +938,9 @@ sub _MaskUpdate {
 
         $JobData{'SearchInArchiveStrg'} = $LayoutObject->BuildSelection(
             Data => {
-                ArchivedTickets    => 'Archived tickets',
-                NotArchivedTickets => 'Unarchived tickets',
-                AllTickets         => 'All tickets',
+                ArchivedTickets    => Translatable('Archived tickets'),
+                NotArchivedTickets => Translatable('Unarchived tickets'),
+                AllTickets         => Translatable('All tickets'),
             },
             Name       => 'SearchInArchive',
             SelectedID => $JobData{SearchInArchive} || 'AllTickets',
@@ -953,8 +954,8 @@ sub _MaskUpdate {
 
         $JobData{'NewArchiveFlagStrg'} = $LayoutObject->BuildSelection(
             Data => {
-                y => 'archive tickets',
-                n => 'restore tickets from archive',
+                y => Translatable('archive tickets'),
+                n => Translatable('restore tickets from archive'),
             },
             Name         => 'NewArchiveFlag',
             PossibleNone => 1,
@@ -1227,7 +1228,7 @@ sub _MaskRun {
     }
     else {
         $LayoutObject->FatalError(
-            Message => "Need Profile!",
+            Message => Translatable('Need Profile!'),
         );
     }
     $JobData{Profile} = $Self->{Profile};
@@ -1280,17 +1281,19 @@ sub _MaskRun {
         }
     }
 
-    # get ticket object
+    # get needed objects
     my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
 
     # perform ticket search
+    my $GenericAgentTicketSearch = $ConfigObject->Get("Ticket::GenericAgentTicketSearch") || {};
     my $Counter = $TicketObject->TicketSearch(
         Result          => 'COUNT',
         SortBy          => 'Age',
         OrderBy         => 'Down',
         UserID          => 1,
         Limit           => 60_000,
-        ConditionInline => 1,
+        ConditionInline => $GenericAgentTicketSearch->{ExtendedSearchCondition},
         %JobData,
         %DynamicFieldSearchParameters,
     ) || 0;
@@ -1301,7 +1304,7 @@ sub _MaskRun {
         OrderBy         => 'Down',
         UserID          => 1,
         Limit           => 30,
-        ConditionInline => 1,
+        ConditionInline => $GenericAgentTicketSearch->{ExtendedSearchCondition},
         %JobData,
         %DynamicFieldSearchParameters,
     );
@@ -1321,7 +1324,7 @@ sub _MaskRun {
         },
     );
 
-    my $RunLimit = $Kernel::OM->Get('Kernel::Config')->Get('Ticket::GenericAgentRunLimit');
+    my $RunLimit = $ConfigObject->Get('Ticket::GenericAgentRunLimit');
     if ( $Counter > $RunLimit ) {
         $LayoutObject->Block(
             Name => 'RunLimit',
@@ -1385,7 +1388,7 @@ sub _MaskRun {
 
     # HTML search mask output
     my $Output = $LayoutObject->Header(
-        Title => 'Affected Tickets',
+        Title => Translatable('Affected Tickets'),
     );
     $Output .= $LayoutObject->NavigationBar();
     $Output .= $LayoutObject->Output(

--- a/Custom/Kernel/Output/HTML/Templates/Standard/AdminGenericAgent.tt
+++ b/Custom/Kernel/Output/HTML/Templates/Standard/AdminGenericAgent.tt
@@ -306,7 +306,7 @@ Core.Agent.Admin.GenericAgent.Init({
                         </div>
                         <div class="Clear"></div>
 
-                        <label for="CustomerUserLogin">[% Translate("Customer login") | html %]:</label>
+                        <label for="CustomerUserLogin">[% Translate("Customer user") | html %]:</label>
                         <div class="Field">
                             <input type="text" name="CustomerUserLogin" id="CustomerUserLogin" class="W33pc" value="[% Data.CustomerUserLogin | html %]"/>
                             <p class="FieldExplanation">
@@ -689,7 +689,7 @@ Core.Agent.Admin.GenericAgent.Init({
                         </div>
                         <div class="Clear"></div>
 
-                        <label for="NewCustomerUserLogin">[% Translate("New customer") | html %]:</label>
+                        <label for="NewCustomerUserLogin">[% Translate("New customer user") | html %]:</label>
                         <div class="Field">
                             <input type="text" name="NewCustomerUserLogin" id="NewCustomerUserLogin" value="[% Data.NewCustomerUserLogin | html %]" class="W33pc"/>
                         </div>

--- a/Custom/Kernel/System/GenericAgent.pm
+++ b/Custom/Kernel/System/GenericAgent.pm
@@ -297,10 +297,7 @@ sub JobRun {
                     . $Preference->{Type}
             };
 
-            if ( !defined($DynamicFieldTemp) )
-            {
-                next PREFERENCE;
-            }
+            next PREFERENCE if !defined $DynamicFieldTemp;
 
             # extract the dynamic field value from the profile
             my $SearchParameter = $DynamicFieldBackendObject->SearchFieldParameterBuild(
@@ -321,14 +318,15 @@ sub JobRun {
         $Job{TicketID} = $Param{OnlyTicketID};
     }
 
-    # get ticket object
+    # get needed objects
     my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
 
     # escalation tickets
     my %Tickets;
 
     # get ticket limit on job run
-    my $RunLimit = $Kernel::OM->Get('Kernel::Config')->Get('Ticket::GenericAgentRunLimit');
+    my $RunLimit = $ConfigObject->Get('Ticket::GenericAgentRunLimit');
     if ( $Job{Escalation} ) {
 
         # Find all tickets which will escalate within the next five days.
@@ -456,10 +454,11 @@ sub JobRun {
             if ( $Self->{NoticeSTDOUT} ) {
                 print " For all Queues: \n";
             }
+            my $GenericAgentTicketSearch = $ConfigObject->Get("Ticket::GenericAgentTicketSearch") || {};
             %Tickets = $TicketObject->TicketSearch(
                 %Job,
                 %DynamicFieldSearchParameters,
-                ConditionInline => 1,
+                ConditionInline => $GenericAgentTicketSearch->{ExtendedSearchCondition},
                 Limit           => $Param{Limit} || $RunLimit,
                 UserID          => $Param{UserID},
             );
@@ -952,9 +951,7 @@ sub _JobRunTicket {
     my $Ticket = "($Param{TicketNumber}/$Param{TicketID})";
 
     # disable sending emails
-    if ( $Param{Config}->{New}->{SendNoNotification} ) {
-        $TicketObject->{SendNoNotification} = 1;
-    }
+    $TicketObject->{SendNoNotification} = $Param{Config}->{New}->{SendNoNotification} ? 1 : 0;
 
     # move ticket
     if ( $Param{Config}->{New}->{Queue} ) {
@@ -1048,6 +1045,22 @@ sub _JobRunTicket {
         );
 
         $IsPendingState = grep { $_ == $Param{Config}->{New}->{StateID} } keys %{ $Self->{PendingStateList} };
+    }
+
+    if (
+        $Param{Config}->{New}->{PendingTime}
+        && !$Param{Config}->{New}->{State}
+        && !$Param{Config}->{New}->{StateID}
+        )
+    {
+        # if pending time is provided, but there is no new ticket state provided,
+        # check if ticket is already in pending state
+        my %Ticket = $TicketObject->TicketGet(
+            TicketID      => $Param{TicketID},
+            DynamicFields => 0,
+        );
+
+        $IsPendingState = grep { $_ eq $Ticket{State} } values %{ $Self->{PendingStateList} };
     }
 
     # set pending time, if new state is pending state

--- a/GenericAgentCustomModuleUnlimitedParams.sopm
+++ b/GenericAgentCustomModuleUnlimitedParams.sopm
@@ -2,18 +2,21 @@
 <otrs_package version="1.0">
     <!-- GENERATED WITH OTRS::OPM::Maker::Command::sopm (1.33) -->
     <Name>GenericAgentCustomModuleUnlimitedParams</Name>
-    <Version>5.0.1</Version>
-    <Framework>5.0.x</Framework>
+    <Version>5.0.2</Version>
+    <Framework Minimum="5.0.14">5.0.x</Framework>
     <Vendor>Perl-Services.de</Vendor>
     <URL>http://www.perl-services.de</URL>
     <Description Lang="de">Erlaubt es unbegrenzt Parameter für eigene Module im GenericAgent zu definieren.</Description>
     <Description Lang="en">Allows to have unlimited parameters for custom modules in GenericAgent.</Description>
+    <Description Lang="hu">Lehetővé teszi, hogy korlátlan sok paramétere legyen az egyéni moduloknál az általános ügyintézőben.</Description>
     <License>GNU AFFERO GENERAL PUBLIC LICENSE Version 3, November 2007</License>
     <Filelist>
         <File Permission="644" Location="Custom/Kernel/Modules/AdminGenericAgent.pm" />
         <File Permission="644" Location="Custom/Kernel/Output/HTML/Templates/Standard/AdminGenericAgent.tt" />
         <File Permission="644" Location="Custom/Kernel/System/GenericAgent.pm" />
         <File Permission="644" Location="Kernel/Config/Files/GenericAgentCustomModuleUnlimitedParams.xml" />
+        <File Permission="644" Location="Kernel/Language/de_GenericAgentCustomModuleUnlimitedParams.pm" />
+        <File Permission="644" Location="Kernel/Language/hu_GenericAgentCustomModuleUnlimitedParams.pm" />
         <File Permission="644" Location="doc/GenericAgentCustomModuleUnlimitedParams.json" />
     </Filelist>
 </otrs_package>

--- a/Kernel/Config/Files/GenericAgentCustomModuleUnlimitedParams.xml
+++ b/Kernel/Config/Files/GenericAgentCustomModuleUnlimitedParams.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <otrs_config version="1.0" init="Config">
     <ConfigItem Name="GenericAgent::MaxNewParam" Required="0" Valid="1">
-        <Description Translatable="1">maximum number of params for custom modul in GenericAgent</Description>
+        <Description Translatable="1">Maximum number of parameters for custom modules in GenericAgent.</Description>
         <Group>GenericAgent</Group>
         <SubGroup>Core</SubGroup>
         <Setting>

--- a/Kernel/Language/de_GenericAgentCustomModuleUnlimitedParams.pm
+++ b/Kernel/Language/de_GenericAgentCustomModuleUnlimitedParams.pm
@@ -1,0 +1,25 @@
+# --
+# Kernel/Language/de_GenericAgentCustomModuleUnlimitedParams.pm - the German translation of GenericAgentCustomModuleUnlimitedParams
+# Copyright (C) 2016 Perl-Services.de, http://perl-services.de/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+package Kernel::Language::de_GenericAgentCustomModuleUnlimitedParams;
+
+use strict;
+use warnings;
+use utf8;
+
+sub Data {
+    my $Self = shift;
+
+    my $Lang = $Self->{Translation} || {};
+
+    # Kernel/Config/Files/GenericAgentCustomModuleUnlimitedParams.xml
+    $Lang->{'Maximum number of parameters for custom modules in GenericAgent.'} = '';
+}
+
+1;

--- a/Kernel/Language/hu_GenericAgentCustomModuleUnlimitedParams.pm
+++ b/Kernel/Language/hu_GenericAgentCustomModuleUnlimitedParams.pm
@@ -1,0 +1,27 @@
+# --
+# Kernel/Language/hu_GenericAgentCustomModuleUnlimitedParams.pm - the Hungarian translation of GenericAgentCustomModuleUnlimitedParams
+# Copyright (C) 2016 Perl-Services.de, http://perl-services.de/
+# Copyright (C) 2016 Balázs Úr, http://www.otrs-megoldasok.hu
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+package Kernel::Language::hu_GenericAgentCustomModuleUnlimitedParams;
+
+use strict;
+use warnings;
+use utf8;
+
+sub Data {
+    my $Self = shift;
+
+    my $Lang = $Self->{Translation} || {};
+
+    # Kernel/Config/Files/GenericAgentCustomModuleUnlimitedParams.xml
+    $Lang->{'Maximum number of parameters for custom modules in GenericAgent.'} =
+        'Az egyéni modulok paramétereinek legnagyobb száma az általános ügyintézőben.';
+}
+
+1;

--- a/doc/GenericAgentCustomModuleUnlimitedParams.json
+++ b/doc/GenericAgentCustomModuleUnlimitedParams.json
@@ -1,17 +1,18 @@
 {
     "name": "GenericAgentCustomModuleUnlimitedParams",
-    "version": "5.0.1",
+    "version": "5.0.2",
     "framework": [
         "5.0.x"
     ],
     "vendor": {
-        "name":  "Perl-Services.de",
+        "name": "Perl-Services.de",
         "url": "http://www.perl-services.de"
     },
     "license": "GNU AFFERO GENERAL PUBLIC LICENSE Version 3, November 2007",
     "description" : {
         "en": "Allows to have unlimited parameters for custom modules in GenericAgent.",
-        "de": "Erlaubt es unbegrenzt Parameter für eigene Module im GenericAgent zu definieren."
+        "de": "Erlaubt es unbegrenzt Parameter für eigene Module im GenericAgent zu definieren.",
+        "hu": "Lehetővé teszi, hogy korlátlan sok paramétere legyen az egyéni moduloknál az általános ügyintézőben."
     },
     "exclude_files" : [
         "TODO"


### PR DESCRIPTION
Hi @reneeb 
This PR contains the following changes:
- synced `Custom/*` files with upstream 5.0.14
- added `Minimum="5.0.14"` attribute to Framework tag in the .sopm (please also add this to `doc/GenericAgentCustomModuleUnlimitedParams.json` if it is needed - and if your package maker supports it)
- added Hungarian translation
- bumped version number, so it is ready to release